### PR TITLE
Allow user defined maximum number of entries within logger window

### DIFF
--- a/Sentinel.Interfaces/ILogger.cs
+++ b/Sentinel.Interfaces/ILogger.cs
@@ -38,5 +38,14 @@
         /// </summary>
         /// <param name="entries">Ordered list/queue of items to add.</param>
         void AddBatch(Queue<ILogEntry> entries);
+
+        /// <summary>
+        /// Allows a specific limit of messages to be applied.
+        /// Note, it is the responsibility of the appender to enforce limits.
+        /// </summary>
+        /// <param name="maximumMessages">
+        /// Number representing the maximum number of entries required.
+        /// </param>
+        void LimitMessageCount(int maximumMessages);
     }
 }

--- a/Sentinel.MSBuild/IMSBuildListenerSettings.cs
+++ b/Sentinel.MSBuild/IMSBuildListenerSettings.cs
@@ -1,6 +1,6 @@
 namespace Sentinel.MSBuild
 {
-    using Interfaces.Providers;
+    using Sentinel.Interfaces.Providers;
 
     public interface IMsBuildListenerSettings : IProviderSettings
     {

--- a/Sentinel.NLog/NLogViewerProvider.cs
+++ b/Sentinel.NLog/NLogViewerProvider.cs
@@ -58,12 +58,6 @@
 
         public int Port { get; private set; }
 
-        ILogger Sentinel.Interfaces.Providers.ILogProvider.Logger
-        {
-            get => throw new NotImplementedException();
-            set => throw new NotImplementedException();
-        }
-
         public void Start()
         {
             Log.Debug("Start requested");

--- a/Sentinel.sln.DotSettings
+++ b/Sentinel.sln.DotSettings
@@ -4,7 +4,7 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSOR_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSORHOLDER_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_FIELD_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
-	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/PreferQualifiedReference/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/PreferQualifiedReference/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/QualifiedUsingAtNestedScope/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>

--- a/Sentinel/Controls/IntegerTextBox.cs
+++ b/Sentinel/Controls/IntegerTextBox.cs
@@ -1,0 +1,16 @@
+﻿namespace Sentinel.Controls
+{
+    using System.Linq;
+    using System.Windows.Controls;
+    using System.Windows.Input;
+
+    public class IntegerTextBox : TextBox
+    {
+        protected override void OnPreviewTextInput(TextCompositionEventArgs e)
+        {
+            e.Handled = !e.Text.All(char.IsDigit);
+
+            base.OnPreviewTextInput(e);
+        }
+    }
+}

--- a/Sentinel/Controls/MainWindow.xaml.cs
+++ b/Sentinel/Controls/MainWindow.xaml.cs
@@ -80,7 +80,6 @@
             GetRecentlyOpenedFiles();
         }
 
-
         // ReSharper disable once MemberCanBePrivate.Global
         public ICommand Add { get; private set; }
 
@@ -174,8 +173,8 @@
         private void ExportLogsAction(object obj)
         {
             // Get Log
-            var tab = (TabItem) tabControl.SelectedItem;
-            var frame = (IWindowFrame) tab.Content;
+            var tab = (TabItem)tabControl.SelectedItem;
+            var frame = (IWindowFrame)tab.Content;
             var restartLogging = false;
 
             // Notify user that log messages will be paused during this operation
@@ -297,7 +296,7 @@
         private void LoadSessionAction(object obj)
         {
             var sessionManager = ServiceLocator.Instance.Get<ISessionManager>();
-            var fileNameToLoad = (string) obj;
+            var fileNameToLoad = (string)obj;
 
             if (!sessionManager.IsSaved)
             {
@@ -367,7 +366,7 @@
             var frame = ServiceLocator.Instance.Get<IWindowFrame>();
 
             // Add to the tab control.
-            var newTab = new TabItem {Header = sessionManager.Name, Content = frame};
+            var newTab = new TabItem { Header = sessionManager.Name, Content = frame };
             tabControl.Items.Add(newTab);
             tabControl.SelectedItem = newTab;
         }
@@ -396,7 +395,7 @@
             var frame = ServiceLocator.Instance.Get<IWindowFrame>();
 
             // Add to the tab control.
-            var tab = new TabItem {Header = sessionManager.Name, Content = frame};
+            var tab = new TabItem { Header = sessionManager.Name, Content = frame };
             tabControl.Items.Add(tab);
             tabControl.SelectedItem = tab;
         }
@@ -508,10 +507,10 @@
             switch (verb)
             {
                 case "nlog":
-                    CreateDefaultNLogListener((NLogOptions) options.Item2, sessionManager);
+                    CreateDefaultNLogListener((NLogOptions)options.Item2, sessionManager);
                     break;
                 case "log4net":
-                    CreateDefaultLog4NetListener((Log4NetOptions) options.Item2, sessionManager);
+                    CreateDefaultLog4NetListener((Log4NetOptions)options.Item2, sessionManager);
                     break;
                 default:
                     sessionManager.LoadSession(commandLineArguments.FirstOrDefault());
@@ -523,7 +522,7 @@
             var frame = ServiceLocator.Instance.Get<IWindowFrame>();
 
             // Add to the tab control.
-            var newTab = new TabItem {Header = sessionManager.Name, Content = frame};
+            var newTab = new TabItem { Header = sessionManager.Name, Content = frame };
             tabControl.Items.Add(newTab);
             tabControl.SelectedItem = newTab;
         }
@@ -568,7 +567,9 @@
                 Name = name,
                 Info = info,
             };
-            var providers = Enumerable.Repeat(new PendingProviderRecord {Info = info, Settings = providerSettings}, 1);
+            var providers = Enumerable.Repeat(
+                new PendingProviderRecord { Info = info, Settings = providerSettings },
+                1);
 
             sessionManager.LoadProviders(providers);
         }
@@ -608,7 +609,7 @@
                 {
                     if (Preferences.Show)
                     {
-                        preferencesWindow = new PreferencesWindow(preferencesWindowTabSelected) {Owner = this};
+                        preferencesWindow = new PreferencesWindow(preferencesWindowTabSelected) { Owner = this };
                         preferencesWindow.Show();
                     }
                     else if (preferencesWindow != null)
@@ -632,17 +633,17 @@
         {
             var windowInfo = new WindowPlacementInfo
             {
-                Height = (int) Height,
-                Top = (int) Top,
-                Left = (int) Left,
-                Width = (int) Width,
+                Height = (int)Height,
+                Top = (int)Top,
+                Left = (int)Left,
+                Width = (int)Width,
                 WindowState = WindowState,
             };
 
             var filename = Path.ChangeExtension(persistingFilename, ".json");
             PersistingSettings.Save(filename, windowInfo, Preferences);
 
-            var recentFileInfo = new RecentFileInfo {RecentFilePaths = RecentFiles.ToList()};
+            var recentFileInfo = new RecentFileInfo { RecentFilePaths = RecentFiles.ToList() };
 
             JsonHelper.SerializeToFile(recentFileInfo, Path.ChangeExtension(persistingRecentFileName, ".json"));
         }
@@ -681,7 +682,7 @@
                 sender.GetType() == typeof(RibbonToggleButton),
                 $"A {sender.GetType()} accessed the wrong method");
 
-            var button = (RibbonToggleButton) sender;
+            var button = (RibbonToggleButton)sender;
             switch (button.Label)
             {
                 case "Highlight":
@@ -780,19 +781,19 @@
             // View-specific bindings
             var collapseIfZero = new CollapseIfZeroConverter();
 
-            var standardHighlighters = new CollectionViewSource {Source = Highlighters.Highlighters};
+            var standardHighlighters = new CollectionViewSource { Source = Highlighters.Highlighters };
             standardHighlighters.View.Filter = c => c is IStandardDebuggingHighlighter;
 
-            var customHighlighters = new CollectionViewSource {Source = Highlighters.Highlighters};
+            var customHighlighters = new CollectionViewSource { Source = Highlighters.Highlighters };
             customHighlighters.View.Filter = c => !(c is IStandardDebuggingHighlighter);
 
             StandardHighlightersRibbonGroup.SetBinding(
                 ItemsControl.ItemsSourceProperty,
-                new Binding {Source = standardHighlighters});
+                new Binding { Source = standardHighlighters });
 
             StandardHighlighterRibbonGroupOnTab.SetBinding(
                 ItemsControl.ItemsSourceProperty,
-                new Binding {Source = standardHighlighters});
+                new Binding { Source = standardHighlighters });
             var collapsingStandardHighlightersBinding = new Binding
             {
                 Source = standardHighlighters,
@@ -803,7 +804,7 @@
 
             CustomHighlighterRibbonGroupOnTab.SetBinding(
                 ItemsControl.ItemsSourceProperty,
-                new Binding {Source = customHighlighters});
+                new Binding { Source = customHighlighters });
 
             var collapsingCustomHighlightersBinding = new Binding
             {
@@ -813,58 +814,58 @@
             };
             CustomHighlighterRibbonGroupOnTab.SetBinding(VisibilityProperty, collapsingCustomHighlightersBinding);
 
-            var standardFilters = new CollectionViewSource {Source = Filters.Filters};
+            var standardFilters = new CollectionViewSource { Source = Filters.Filters };
             standardFilters.View.Filter = c => c is IStandardDebuggingFilter;
 
-            var customFilters = new CollectionViewSource {Source = Filters.Filters};
+            var customFilters = new CollectionViewSource { Source = Filters.Filters };
             customFilters.View.Filter = c => !(c is IStandardDebuggingFilter);
 
             StandardFiltersRibbonGroup.SetBinding(
                 ItemsControl.ItemsSourceProperty,
-                new Binding {Source = standardFilters});
+                new Binding { Source = standardFilters });
 
             StandardFiltersRibbonGroupOnTab.SetBinding(
                 ItemsControl.ItemsSourceProperty,
-                new Binding {Source = standardFilters});
+                new Binding { Source = standardFilters });
 
             StandardFiltersRibbonGroupOnTab.SetBinding(
                 VisibilityProperty,
-                new Binding {Source = standardFilters, Path = new PropertyPath("Count"), Converter = collapseIfZero});
+                new Binding { Source = standardFilters, Path = new PropertyPath("Count"), Converter = collapseIfZero });
             CustomFiltersRibbonGroupOnTab.SetBinding(
                 ItemsControl.ItemsSourceProperty,
-                new Binding {Source = customFilters});
+                new Binding { Source = customFilters });
             CustomFiltersRibbonGroupOnTab.SetBinding(
                 VisibilityProperty,
-                new Binding {Source = customFilters, Path = new PropertyPath("Count"), Converter = collapseIfZero});
+                new Binding { Source = customFilters, Path = new PropertyPath("Count"), Converter = collapseIfZero });
 
             var customExtractors = Extractors.Extractors;
             CustomExtractorsRibbonGroupOnTab.SetBinding(
                 ItemsControl.ItemsSourceProperty,
-                new Binding {Source = customExtractors});
+                new Binding { Source = customExtractors });
 
             var customClassifyiers = ClassifyingService.Classifiers;
             CustomClassifiersRibbonGroupOnTab.SetBinding(
                 ItemsControl.ItemsSourceProperty,
-                new Binding {Source = customClassifyiers});
+                new Binding { Source = customClassifyiers });
 
             BindToSearchElements();
 
             // Column view buttons
             ExceptionRibbonToggleButton.SetBinding(
                 ToggleButton.IsCheckedProperty,
-                new Binding {Source = Preferences, Path = new PropertyPath("ShowExceptionColumn")});
+                new Binding { Source = Preferences, Path = new PropertyPath("ShowExceptionColumn") });
             ThreadRibbonToggleButton.SetBinding(
                 ToggleButton.IsCheckedProperty,
-                new Binding {Source = Preferences, Path = new PropertyPath("ShowThreadColumn")});
+                new Binding { Source = Preferences, Path = new PropertyPath("ShowThreadColumn") });
             SourceHostRibbonToggleButton.SetBinding(
                 ToggleButton.IsCheckedProperty,
-                new Binding {Source = Preferences, Path = new PropertyPath("ShowSourceColumn")});
+                new Binding { Source = Preferences, Path = new PropertyPath("ShowSourceColumn") });
             DebugSourceRibbonToggleButton.SetBinding(
                 ToggleButton.IsCheckedProperty,
-                new Binding {Source = Preferences, Path = new PropertyPath("ShowSourceInformationColumns")});
+                new Binding { Source = Preferences, Path = new PropertyPath("ShowSourceInformationColumns") });
             ContextRibbonToggleButton.SetBinding(
                 ToggleButton.IsCheckedProperty,
-                new Binding {Source = Preferences, Path = new PropertyPath("ShowContextColumn")});
+                new Binding { Source = Preferences, Path = new PropertyPath("ShowContextColumn") });
         }
 
         private void BindToSearchElements()

--- a/Sentinel/Controls/PersistingSettings.cs
+++ b/Sentinel/Controls/PersistingSettings.cs
@@ -3,11 +3,18 @@
     using System;
     using System.Diagnostics;
     using System.Runtime.Serialization;
+    using Sentinel.Interfaces;
     using Sentinel.Support;
 
     [DataContract]
     public class PersistingSettings
     {
+        [DataMember]
+        public WindowPlacementInfo WindowPlacementInfo { get; set; }
+
+        [DataMember]
+        public IUserPreferences UserPreferences { get; set; }
+
         internal static PersistingSettings Load(string fileName)
         {
             if (string.IsNullOrWhiteSpace(fileName))
@@ -28,21 +35,42 @@
                     .Replace("\r", string.Empty)
                     .Replace("\n", string.Empty);
 
-                var version = -1;
                 switch (fileHeader)
                 {
                     case "{\"$type\":\"Sentinel.Controls.WindowPlacementInfo":
                         return DeserializeFromV1(fileContents);
-                    case "version2":
-                        version = 2;
+                    case "{\"$type\":\"Sentinel.Controls.PersistingSettings,":
+                        return DeserializeFromV2(fileContents);
                         break;
                     default:
-                        version = -1;
-                        break;
+                        return null;
                 }
             }
 
             return null;
+        }
+
+        internal static void Save(string fileName, WindowPlacementInfo placementInfo, IUserPreferences userPreferences)
+        {
+            if (string.IsNullOrWhiteSpace(fileName))
+            {
+                throw new ArgumentException("Value cannot be null or whitespace.", nameof(fileName));
+            }
+
+            var wrapper = new PersistingSettings
+            {
+                WindowPlacementInfo = placementInfo,
+                UserPreferences = userPreferences,
+            };
+
+            try
+            {
+                JsonHelper.SerializeToFile(wrapper, fileName);
+            }
+            catch (Exception e)
+            {
+                Trace.TraceError($"Unable to write persistence file: {e.Message}");
+            }
         }
 
         private static PersistingSettings DeserializeFromV1(string fileContents)
@@ -66,7 +94,19 @@
             return wrapper;
         }
 
-        [DataMember]
-        public WindowPlacementInfo WindowPlacementInfo { get; set; }
+        private static PersistingSettings DeserializeFromV2(string fileContents)
+        {
+            Trace.WriteLine("DeserializeFromV1");
+
+            try
+            {
+                return JsonHelper.DeserializeFromString<PersistingSettings>(fileContents);
+            }
+            catch (Exception e)
+            {
+                Trace.TraceError($"Deserialize error: {e.Message}");
+                return null;
+            }
+        }
     }
 }

--- a/Sentinel/Controls/PersistingSettings.cs
+++ b/Sentinel/Controls/PersistingSettings.cs
@@ -41,7 +41,6 @@
                         return DeserializeFromV1(fileContents);
                     case "{\"$type\":\"Sentinel.Controls.PersistingSettings,":
                         return DeserializeFromV2(fileContents);
-                        break;
                     default:
                         return null;
                 }
@@ -83,7 +82,7 @@
             {
                 wrapper = new PersistingSettings
                 {
-                    WindowPlacementInfo = JsonHelper.DeserializeFromString<WindowPlacementInfo>(fileContents)
+                    WindowPlacementInfo = JsonHelper.DeserializeFromString<WindowPlacementInfo>(fileContents),
                 };
             }
             catch (Exception e)

--- a/Sentinel/Controls/PersistingSettings.cs
+++ b/Sentinel/Controls/PersistingSettings.cs
@@ -1,0 +1,72 @@
+﻿namespace Sentinel.Controls
+{
+    using System;
+    using System.Diagnostics;
+    using System.Runtime.Serialization;
+    using Sentinel.Support;
+
+    [DataContract]
+    public class PersistingSettings
+    {
+        internal static PersistingSettings Load(string fileName)
+        {
+            if (string.IsNullOrWhiteSpace(fileName))
+            {
+                throw new System.ArgumentException("Value cannot be null or whitespace.", nameof(fileName));
+            }
+
+            // Note that PersistingSettings is a new file format, so need to detect whether using
+            // new serialisation or upgrading.
+            if (System.IO.File.Exists(fileName))
+            {
+                var fileContents = System.IO.File.ReadAllText(fileName);
+
+                // Version detect from file-header signature:
+                var fileHeader = fileContents
+                    .Substring(0, 52)
+                    .Replace(" ", string.Empty)
+                    .Replace("\r", string.Empty)
+                    .Replace("\n", string.Empty);
+
+                var version = -1;
+                switch (fileHeader)
+                {
+                    case "{\"$type\":\"Sentinel.Controls.WindowPlacementInfo":
+                        return DeserializeFromV1(fileContents);
+                    case "version2":
+                        version = 2;
+                        break;
+                    default:
+                        version = -1;
+                        break;
+                }
+            }
+
+            return null;
+        }
+
+        private static PersistingSettings DeserializeFromV1(string fileContents)
+        {
+            Trace.WriteLine("DeserializeFromV1");
+
+            PersistingSettings wrapper = null;
+
+            try
+            {
+                wrapper = new PersistingSettings
+                {
+                    WindowPlacementInfo = JsonHelper.DeserializeFromString<WindowPlacementInfo>(fileContents)
+                };
+            }
+            catch (Exception e)
+            {
+                Trace.TraceError($"Deserialize error: {e.Message}");
+            }
+
+            return wrapper;
+        }
+
+        [DataMember]
+        public WindowPlacementInfo WindowPlacementInfo { get; set; }
+    }
+}

--- a/Sentinel/Controls/PreferencesControl.xaml
+++ b/Sentinel/Controls/PreferencesControl.xaml
@@ -164,7 +164,7 @@
                                     <StackPanel IsEnabled="{Binding Preferences.LimitMessages}"
                                                 Orientation="Horizontal">
                                         <Label Margin="20,0,0,0">Message count:</Label>
-                                        <TextBox
+                                        <controls:IntegerTextBox
                                             Text="{Binding Preferences.MaximumMessageCount, UpdateSourceTrigger=PropertyChanged}"
                                             Margin="10,0,0,0"
                                             Width="100"

--- a/Sentinel/Controls/PreferencesControl.xaml
+++ b/Sentinel/Controls/PreferencesControl.xaml
@@ -20,143 +20,173 @@
     <Grid x:Name="LayoutRoot">
         <TabControl SelectedIndex="{Binding SelectedTabIndex}">
             <TabItem Header="General">
-                <DockPanel Margin="5">
-                    <StackPanel DockPanel.Dock="Top">
-                        <GroupBox Header="Column options">
-                            <Grid Margin="5">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                </Grid.RowDefinitions>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="5" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
+                <ScrollViewer HorizontalScrollBarVisibility="Hidden"
+                              VerticalScrollBarVisibility="Auto">
+                    <DockPanel Margin="5">
+                        <StackPanel DockPanel.Dock="Top">
+                            <GroupBox Header="Column options">
+                                <Grid Margin="5">
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                    </Grid.RowDefinitions>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="5" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
 
-                                <TextBlock Grid.Row="0"
-                                           Grid.Column="0"
-                                           VerticalAlignment="Center"
-                                           Text="Issue Types column :" />
-                                <ComboBox Grid.Row="0"
-                                          Grid.Column="2"
-                                          SelectedIndex="{Binding Preferences.SelectedTypeOption}"
-                                          Width="Auto"
-                                          HorizontalAlignment="Left"
-                                          Margin="0,5,0,5"
-                                          ItemsSource="{Binding Preferences.TypeOptions}"
-                                          MinWidth="100" />
-                                <TextBlock Grid.Row="1"
-                                           Grid.Column="0"
-                                           VerticalAlignment="Center"
-                                           Text="Date Format :" />
-                                <ComboBox Grid.Row="1"
-                                          Grid.Column="2"
-                                          SelectedIndex="{Binding Preferences.SelectedDateOption}"
-                                          HorizontalAlignment="Left"
-                                          Margin="0,5,0,5"
-                                          ItemsSource="{Binding Preferences.DateFormatOptions}"
-                                          MinWidth="100" />
-                                <TextBlock Grid.Row="2"
-                                           Grid.Column="0"
-                                           Margin="0,8"
-                                           VerticalAlignment="Top"
-                                           Text="Time Format :" />
-                                <StackPanel Grid.Row="2"
-                                            Grid.Column="2"
-                                            Orientation="Vertical">
-                                    <ComboBox SelectedIndex="{Binding Preferences.SelectedTimeFormatOption}"
+                                    <TextBlock Grid.Row="0"
+                                               Grid.Column="0"
+                                               VerticalAlignment="Center"
+                                               Text="Issue Types column :" />
+                                    <ComboBox Grid.Row="0"
+                                              Grid.Column="2"
+                                              SelectedIndex="{Binding Preferences.SelectedTypeOption}"
+                                              Width="Auto"
+                                              HorizontalAlignment="Left"
                                               Margin="0,5,0,5"
+                                              ItemsSource="{Binding Preferences.TypeOptions}"
+                                              MinWidth="100" />
+                                    <TextBlock Grid.Row="1"
+                                               Grid.Column="0"
+                                               VerticalAlignment="Center"
+                                               Text="Date Format :" />
+                                    <ComboBox Grid.Row="1"
+                                              Grid.Column="2"
+                                              SelectedIndex="{Binding Preferences.SelectedDateOption}"
                                               HorizontalAlignment="Left"
-                                          ItemsSource="{Binding Preferences.TimeFormatOptions}"
-                                          MinWidth="100" />
-                                    <CheckBox Margin="0,5,0,5"
-                                              IsChecked="{Binding Preferences.ConvertUtcTimesToLocalTimeZone}">Convert UTC times to local timezone</CheckBox>
-                                </StackPanel>
-                                <TextBlock Grid.Row="3"
-                                           Grid.Column="0"
-                                           Margin="0,4"
-                                           VerticalAlignment="Top"
-                                           Text="Message Date/Time value :" />
-                                <StackPanel Grid.Row="3"
-                                            Grid.Column="2">
-                                    <RadioButton Margin="0,5,0,5"
-                                                 IsChecked="{Binding Preferences.UseArrivalDateTime}">Use time of message receipt by Sentinel</RadioButton>
-                                    <RadioButton Margin="0,0,0,5"
-                                                 IsChecked="{Binding Preferences.UseArrivalDateTime, Converter={StaticResource BooleanInverterConverter}}">Use sender's time</RadioButton>
-                                </StackPanel>
-                                <StackPanel Orientation="Vertical"
-                                            Grid.Row="4"
-                                            Margin="0,5,0,5"
-                                            Grid.ColumnSpan="3"
-                                            Grid.Column="0">
-                                    <CheckBox IsChecked="{Binding Preferences.ShowExceptionColumn}"
-                                              HorizontalAlignment="Left"
-                                              MinWidth="100"
-                                              Margin="0,0,0,5"
-                                              ToolTip="Showing exceptions will become useful once it is fully implemented."
-                                              Content="Show the Exception column" />
-                                    <CheckBox IsChecked="{Binding Preferences.ShowThreadColumn}"
-                                              HorizontalAlignment="Left"
-                                              MinWidth="100"
-                                              Margin="0,0,0,5"
-                                              ToolTip="Showing the originating thread may not always be useful.  The thread identifier (a number) is unique only to the original application.  This can be misleading when multiple applications are being logged, additionally, a correctly named system will yield a more useful context."
-                                              Content="Show the Thread column" />
-                                    <CheckBox IsChecked="{Binding Preferences.ShowSourceColumn}" 
-                                              HorizontalAlignment="Left"
-                                              MinWidth="100"
-                                              Margin="0,0,0,5"
-                                              ToolTip="Show the name of the machine from which the message was sourced"
-                                              Content="Show the message source host-name column"/>
-                                    <CheckBox IsChecked="{Binding Preferences.ShowSourceInformationColumns}"
-                                              HorizontalAlignment="Left"
-                                              Margin="0,0,0,5"
-                                              ToolTip="Shows/hides the columns with the source-code information (nLog only)"
-                                              Content="Show source debugging information" />
-                                    <StackPanel Orientation="Horizontal"
-                                                VerticalAlignment="Center">
-                                        <CheckBox IsChecked="{Binding Preferences.ShowContextColumn}"
+                                              Margin="0,5,0,5"
+                                              ItemsSource="{Binding Preferences.DateFormatOptions}"
+                                              MinWidth="100" />
+                                    <TextBlock Grid.Row="2"
+                                               Grid.Column="0"
+                                               Margin="0,8"
+                                               VerticalAlignment="Top"
+                                               Text="Time Format :" />
+                                    <StackPanel Grid.Row="2"
+                                                Grid.Column="2"
+                                                Orientation="Vertical">
+                                        <ComboBox SelectedIndex="{Binding Preferences.SelectedTimeFormatOption}"
+                                                  Margin="0,5,0,5"
                                                   HorizontalAlignment="Left"
-                                                  VerticalAlignment="Bottom"
-                                                  Margin="0,0,0,5"
-                                                  ToolTip="Shows/hides the context column (nLog only)"
-                                                  Content="Show the context column" />
-                                        <Label Margin="20,0,0,0">Property for context:</Label>
-                                        <TextBox Text="{Binding Preferences.ContextProperty, UpdateSourceTrigger=PropertyChanged}" 
-                                                 Margin="10,0,0,0"
-                                                 Width="200"
-                                                 VerticalAlignment="Center" />
+                                                  ItemsSource="{Binding Preferences.TimeFormatOptions}"
+                                                  MinWidth="100" />
+                                        <CheckBox Margin="0,5,0,5"
+                                                  IsChecked="{Binding Preferences.ConvertUtcTimesToLocalTimeZone}">
+                                            Convert UTC times to local timezone
+                                        </CheckBox>
                                     </StackPanel>
-                                    <CheckBox IsChecked="{Binding Preferences.UseLazyRebuild}"
+                                    <TextBlock Grid.Row="3"
+                                               Grid.Column="0"
+                                               Margin="0,4"
+                                               VerticalAlignment="Top"
+                                               Text="Message Date/Time value :" />
+                                    <StackPanel Grid.Row="3"
+                                                Grid.Column="2">
+                                        <RadioButton Margin="0,5,0,5"
+                                                     IsChecked="{Binding Preferences.UseArrivalDateTime}">
+                                            Use time of message receipt by Sentinel
+                                        </RadioButton>
+                                        <RadioButton Margin="0,0,0,5"
+                                                     IsChecked="{Binding Preferences.UseArrivalDateTime, Converter={StaticResource BooleanInverterConverter}}">
+                                            Use sender's time
+                                        </RadioButton>
+                                    </StackPanel>
+                                    <StackPanel Orientation="Vertical"
+                                                Grid.Row="4"
+                                                Margin="0,5,0,5"
+                                                Grid.ColumnSpan="3"
+                                                Grid.Column="0">
+                                        <CheckBox IsChecked="{Binding Preferences.ShowExceptionColumn}"
+                                                  HorizontalAlignment="Left"
+                                                  MinWidth="100"
+                                                  Margin="0,0,0,5"
+                                                  ToolTip="Showing exceptions will become useful once it is fully implemented."
+                                                  Content="Show the Exception column" />
+                                        <CheckBox IsChecked="{Binding Preferences.ShowThreadColumn}"
+                                                  HorizontalAlignment="Left"
+                                                  MinWidth="100"
+                                                  Margin="0,0,0,5"
+                                                  ToolTip="Showing the originating thread may not always be useful.  The thread identifier (a number) is unique only to the original application.  This can be misleading when multiple applications are being logged, additionally, a correctly named system will yield a more useful context."
+                                                  Content="Show the Thread column" />
+                                        <CheckBox IsChecked="{Binding Preferences.ShowSourceColumn}"
+                                                  HorizontalAlignment="Left"
+                                                  MinWidth="100"
+                                                  Margin="0,0,0,5"
+                                                  ToolTip="Show the name of the machine from which the message was sourced"
+                                                  Content="Show the message source host-name column" />
+                                        <CheckBox IsChecked="{Binding Preferences.ShowSourceInformationColumns}"
+                                                  HorizontalAlignment="Left"
+                                                  Margin="0,0,0,5"
+                                                  ToolTip="Shows/hides the columns with the source-code information (nLog only)"
+                                                  Content="Show source debugging information" />
+                                        <StackPanel Orientation="Horizontal"
+                                                    VerticalAlignment="Center">
+                                            <CheckBox IsChecked="{Binding Preferences.ShowContextColumn}"
+                                                      HorizontalAlignment="Left"
+                                                      VerticalAlignment="Bottom"
+                                                      Margin="0,0,0,5"
+                                                      ToolTip="Shows/hides the context column (nLog only)"
+                                                      Content="Show the context column" />
+                                            <Label Margin="20,0,0,0">Property for context:</Label>
+                                            <TextBox
+                                                Text="{Binding Preferences.ContextProperty, UpdateSourceTrigger=PropertyChanged}"
+                                                Margin="10,0,0,0"
+                                                Width="200"
+                                                VerticalAlignment="Center" />
+                                        </StackPanel>
+                                        <CheckBox IsChecked="{Binding Preferences.UseLazyRebuild}"
+                                                  HorizontalAlignment="Left"
+                                                  ToolTip="Enables/disables live resorting of sortable columns"
+                                                  Content="Enable live column resorting mode" />
+                                    </StackPanel>
+                                </Grid>
+                            </GroupBox>
+                            <GroupBox Header="Row options">
+                                <CheckBox Margin="5"
+                                          Content="Use tighter row separation on Vista / Windows7"
+                                          ToolTip="Vista and Windows 7 put spacing around each row that takes up a fair amount of space, enabling this option tries to reduce the space to something like that used by Windows XP"
+                                          IsChecked="{Binding Preferences.UseTighterRows}" />
+                            </GroupBox>
+                            <GroupBox Header="Message limits">
+                                <StackPanel Orientation="Horizontal"
+                                            Margin="5"
+                                            VerticalAlignment="Center">
+                                    <CheckBox IsChecked="{Binding Preferences.LimitMessages}"
                                               HorizontalAlignment="Left"
-                                              ToolTip="Enables/disables live resorting of sortable columns"
-                                              Content="Enable live column resorting mode" />
+                                              VerticalAlignment="Bottom"
+                                              Margin="0,0,0,5"
+                                              Content="Limit the maximum number of messages retained" />
+                                    <StackPanel IsEnabled="{Binding Preferences.LimitMessages}"
+                                                Orientation="Horizontal">
+                                        <Label Margin="20,0,0,0">Message count:</Label>
+                                        <TextBox
+                                            Text="{Binding Preferences.MaximumMessageCount, UpdateSourceTrigger=PropertyChanged}"
+                                            Margin="10,0,0,0"
+                                            Width="100"
+                                            VerticalAlignment="Center" />
+                                    </StackPanel>
                                 </StackPanel>
-                            </Grid>
-                        </GroupBox>
-                        <GroupBox Header="Row options">
-                            <CheckBox Margin="5"
-                                      Content="Use tighter row seperation on Vista / Windows7"
-                                      ToolTip="Vista and Windows 7 put spacing around each row that takes up a fair amount of space, enabling this option tries to reduce the space to something like that used by Windows XP" 
-                                      IsChecked="{Binding Preferences.UseTighterRows}"/>
-                        </GroupBox>
-                        <GroupBox Header="Layout">
-                            <CheckBox Margin="5"
-                                      Content="Use Stacked Layout"
-                                      ToolTip="Orientate the two windows as stacked rather than side-by-side."
-                                      IsChecked="{Binding Preferences.UseStackedLayout}" />
-                        </GroupBox>
-                        <GroupBox Header="Interactions">
-                            <CheckBox Margin="5"
-                                      Content="Show exceptions panel on double-click"
-                                      ToolTip="When a log entry has additional exception information, double-clicking will show the exception detail panel."
-                                      IsChecked="{Binding Preferences.DoubleClickToShowExceptions}" />
-                        </GroupBox>
-                    </StackPanel>
-                </DockPanel>
+                            </GroupBox>
+                            <GroupBox Header="Layout">
+                                <CheckBox Margin="5"
+                                          Content="Use Stacked Layout"
+                                          ToolTip="Orientate the two windows as stacked rather than side-by-side."
+                                          IsChecked="{Binding Preferences.UseStackedLayout}" />
+                            </GroupBox>
+                            <GroupBox Header="Interactions">
+                                <CheckBox Margin="5"
+                                          Content="Show exceptions panel on double-click"
+                                          ToolTip="When a log entry has additional exception information, double-clicking will show the exception detail panel."
+                                          IsChecked="{Binding Preferences.DoubleClickToShowExceptions}" />
+                            </GroupBox>
+                        </StackPanel>
+                    </DockPanel>
+                </ScrollViewer>
             </TabItem>
             <TabItem Header="Classifiers">
                 <GroupBox Header="Available Classifiers"
@@ -165,8 +195,9 @@
                         <StackPanel Margin="5"
                                     DockPanel.Dock="Top">
                             <TextBlock TextWrapping="WrapWithOverflow">
-                            <Run Text="Classifiers change the type of log messages when enabled." />
-                            <Run Text="Messages are classified as they are received and cannot be changed afterwards." />
+                                <Run Text="Classifiers change the type of log messages when enabled." />
+                                <Run
+                                    Text="Messages are classified as they are received and cannot be changed afterwards." />
                             </TextBlock>
                             <TextBlock TextWrapping="WrapWithOverflow"
                                        Margin="0,5,0,5"
@@ -183,9 +214,9 @@
                         <StackPanel Margin="5"
                                     DockPanel.Dock="Top">
                             <TextBlock TextWrapping="WrapWithOverflow">
-                            <Run Text="Highlighters change the appearance of matching log messages when enabled" />
-                            <Run Text="so that certain messages are made to stand out from others." />
-                            <Run Text="An example would be marking Error messages in a red background." />
+                                <Run Text="Highlighters change the appearance of matching log messages when enabled" />
+                                <Run Text="so that certain messages are made to stand out from others." />
+                                <Run Text="An example would be marking Error messages in a red background." />
                             </TextBlock>
                             <TextBlock TextWrapping="WrapWithOverflow"
                                        Margin="0,5,0,5"
@@ -202,12 +233,13 @@
                         <StackPanel Margin="5"
                                     DockPanel.Dock="Top">
                             <TextBlock TextWrapping="WrapWithOverflow">
-                            <Run Text="Filters remove matching log messages from view when enabled." />                            
-                            <Run Text="They do not prevent the messages from being recorded, just from being displayed." />
+                                <Run Text="Filters remove matching log messages from view when enabled." />
+                                <Run
+                                    Text="They do not prevent the messages from being recorded, just from being displayed." />
                             </TextBlock>
                             <TextBlock TextWrapping="WrapWithOverflow"
-                                   Margin="0,5,0,5"
-                                   Text="The list below indicates the available filters that may be applied:" />
+                                       Margin="0,5,0,5"
+                                       Text="The list below indicates the available filters that may be applied:" />
                         </StackPanel>
                         <filters:FiltersControl Height="Auto"
                                                 VerticalAlignment="Stretch" />
@@ -216,20 +248,21 @@
             </TabItem>
             <TabItem Header="Extractors">
                 <GroupBox Header="Available Extractors"
-                    Margin="5">
+                          Margin="5">
                     <DockPanel>
                         <StackPanel Margin="5"
                                     DockPanel.Dock="Top">
                             <TextBlock TextWrapping="WrapWithOverflow">
-                            <Run Text="Extractors remove unmatching log messages from view when enabled." />                            
-                            <Run Text="They do not prevent the messages from being recorded, just from being displayed." />
+                                <Run Text="Extractors remove unmatching log messages from view when enabled." />
+                                <Run
+                                    Text="They do not prevent the messages from being recorded, just from being displayed." />
                             </TextBlock>
                             <TextBlock TextWrapping="WrapWithOverflow"
-                                   Margin="0,5,0,5"
-                                   Text="The list below indicates the available extractors that may be applied:" />
+                                       Margin="0,5,0,5"
+                                       Text="The list below indicates the available extractors that may be applied:" />
                         </StackPanel>
                         <extractors:ExtractorsControl Height="Auto"
-                                                VerticalAlignment="Stretch" />
+                                                      VerticalAlignment="Stretch" />
                     </DockPanel>
                 </GroupBox>
             </TabItem>
@@ -240,13 +273,13 @@
                         <StackPanel Margin="5"
                                     DockPanel.Dock="Top">
                             <TextBlock TextWrapping="WrapWithOverflow">
-                            <Run Text="Images are displayed for log messages by matching types." />
-                            <Run Text="They are displayed for Classifiers, Highlighters, Filters, and Extractors" />                            
-                            <Run Text="by matching names." />
+                                <Run Text="Images are displayed for log messages by matching types." />
+                                <Run Text="They are displayed for Classifiers, Highlighters, Filters, and Extractors" />
+                                <Run Text="by matching names." />
                             </TextBlock>
                             <TextBlock TextWrapping="WrapWithOverflow"
-                                   Margin="0,5,0,5"
-                                   Text="The list below indicates the registered images:" />
+                                       Margin="0,5,0,5"
+                                       Text="The list below indicates the registered images:" />
                         </StackPanel>
                         <controls:ImageTypesControl />
                     </DockPanel>
@@ -259,7 +292,8 @@
                         <StackPanel Margin="5"
                                     DockPanel.Dock="Top">
                             <TextBlock TextWrapping="WrapWithOverflow">
-                                <Run Text="When specific logging messages are sent, interpret them as commands for controlling Sentinel." />
+                                <Run
+                                    Text="When specific logging messages are sent, interpret them as commands for controlling Sentinel." />
                             </TextBlock>
                             <Grid>
                                 <Grid.ColumnDefinitions>

--- a/Sentinel/Interfaces/IUserPreferences.cs
+++ b/Sentinel/Interfaces/IUserPreferences.cs
@@ -65,5 +65,12 @@ namespace Sentinel.Interfaces
 
         [DataMember]
         string ClearCommandMatchText { get; set; }
+
+        [DataMember]
+        bool LimitMessages { get; set; }
+
+        // TODO: this should be an integer bound to a numeric control.
+        [DataMember]
+        string MaximumMessageCount { get; set; }
     }
 }

--- a/Sentinel/Logs/Log.cs
+++ b/Sentinel/Logs/Log.cs
@@ -113,6 +113,20 @@ namespace Sentinel.Logs
             OnPropertyChanged(nameof(NewEntries));
         }
 
+        public void LimitMessageCount(int maximumMessages)
+        {
+            lock (entries)
+            {
+                var messages = entries.Count;
+                var excessMessages = messages - maximumMessages;
+
+                if (excessMessages > 0)
+                {
+                    entries.RemoveRange(0, excessMessages);
+                }
+            }
+        }
+
         private void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             if (e.PropertyName == "NewEntries")

--- a/Sentinel/Preferences/UserPreferences.cs
+++ b/Sentinel/Preferences/UserPreferences.cs
@@ -87,7 +87,7 @@
             "dddd",
         };
 
-        public IEnumerable<string> TimeFormatOptions { get; } = new[] {"HH:mm:ss;FFFF", "HH:mm:ss", "HH:mm"};
+        public IEnumerable<string> TimeFormatOptions { get; } = new[] { "HH:mm:ss;FFFF", "HH:mm:ss", "HH:mm" };
 
         /// <summary>
         /// Gets or sets the selected date option, as a index of the available options.
@@ -245,7 +245,7 @@
         /// <summary>
         /// Gets a list of the available type column options, such as hidden, icons, text, etc.
         /// </summary>
-        public IEnumerable<string> TypeOptions => new[] {"Hidden", "Icons", "Text", "Icon and text"};
+        public IEnumerable<string> TypeOptions => new[] { "Hidden", "Icons", "Text", "Icon and text" };
 
         /// <summary>
         /// Gets or sets a value indicating whether the lazy rebuilding option should be used

--- a/Sentinel/Preferences/UserPreferences.cs
+++ b/Sentinel/Preferences/UserPreferences.cs
@@ -54,15 +54,19 @@
 
         private string clearCommandMatchText = "#!Clear";
 
+        private bool limitMessages = false;
+
+        private string maximumMessageCount;
+
         public UserPreferences()
         {
             PropertyChanged += (s, a) =>
+            {
+                if (a.PropertyName == nameof(ContextProperty))
                 {
-                    if (a.PropertyName == nameof(ContextProperty))
-                    {
-                        Log.Debug($"{a.PropertyName}={ContextProperty}");
-                    }
-                };
+                    Log.Debug($"{a.PropertyName}={ContextProperty}");
+                }
+            };
         }
 
         /// <summary>
@@ -83,7 +87,7 @@
             "dddd",
         };
 
-        public IEnumerable<string> TimeFormatOptions { get; } = new[] { "HH:mm:ss;FFFF", "HH:mm:ss", "HH:mm" };
+        public IEnumerable<string> TimeFormatOptions { get; } = new[] {"HH:mm:ss;FFFF", "HH:mm:ss", "HH:mm"};
 
         /// <summary>
         /// Gets or sets the selected date option, as a index of the available options.
@@ -241,7 +245,7 @@
         /// <summary>
         /// Gets a list of the available type column options, such as hidden, icons, text, etc.
         /// </summary>
-        public IEnumerable<string> TypeOptions => new[] { "Hidden", "Icons", "Text", "Icon and text" };
+        public IEnumerable<string> TypeOptions => new[] {"Hidden", "Icons", "Text", "Icon and text"};
 
         /// <summary>
         /// Gets or sets a value indicating whether the lazy rebuilding option should be used
@@ -382,6 +386,32 @@
                 {
                     clearCommandMatchText = value;
                     OnPropertyChanged(nameof(ClearCommandMatchText));
+                }
+            }
+        }
+
+        public bool LimitMessages
+        {
+            get => limitMessages;
+            set
+            {
+                if (value != limitMessages)
+                {
+                    limitMessages = value;
+                    OnPropertyChanged(nameof(LimitMessages));
+                }
+            }
+        }
+
+        public string MaximumMessageCount
+        {
+            get => maximumMessageCount;
+            set
+            {
+                if (maximumMessageCount != value)
+                {
+                    maximumMessageCount = value;
+                    OnPropertyChanged(nameof(MaximumMessageCount));
                 }
             }
         }

--- a/Sentinel/Sentinel.csproj
+++ b/Sentinel/Sentinel.csproj
@@ -209,6 +209,7 @@
     <Compile Include="Controls\PersistingSettings.cs" />
     <Compile Include="Controls\RecentFileInfo.cs" />
     <Compile Include="Controls\WindowPlacementInfo.cs" />
+    <Compile Include="Controls\IntegerTextBox.cs" />
     <Compile Include="Extractors\ExtractingService.cs" />
     <Compile Include="Extractors\Extractor.cs" />
     <Compile Include="Extractors\Gui\AddEditExtractor.cs" />

--- a/Sentinel/Sentinel.csproj
+++ b/Sentinel/Sentinel.csproj
@@ -206,6 +206,7 @@
     <Compile Include="Controls\AboutWindow.xaml.cs">
       <DependentUpon>AboutWindow.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Controls\PersistingSettings.cs" />
     <Compile Include="Controls\RecentFileInfo.cs" />
     <Compile Include="Controls\WindowPlacementInfo.cs" />
     <Compile Include="Extractors\ExtractingService.cs" />

--- a/Sentinel/Views/Gui/LogMessages.cs
+++ b/Sentinel/Views/Gui/LogMessages.cs
@@ -8,13 +8,11 @@
     using System.Linq;
     using System.Windows.Controls;
     using System.Windows.Threading;
-
     using Sentinel.Extractors.Interfaces;
     using Sentinel.Filters.Interfaces;
     using Sentinel.Interfaces;
     using Sentinel.Services;
     using Sentinel.Views.Interfaces;
-
     using WpfExtras;
 
     public class LogMessages : ViewModelBase, ILogViewer
@@ -51,20 +49,20 @@
 
         public LogMessages()
         {
-            ((ViewInformation)Info).Description = DESCRIPTION;
+            ((ViewInformation) Info).Description = DESCRIPTION;
             presenter = new LogMessagesControl
-                            {
-                                DataContext = this,
-                            };
+            {
+                DataContext = this,
+            };
 
             Messages = new ObservableCollection<ILogEntry>();
 
             PropertyChanged += PropertyChangedHandler;
 
             var dt = new DispatcherTimer(DispatcherPriority.Normal)
-                         {
-                             Interval = TimeSpan.FromMilliseconds(200),
-                         };
+            {
+                Interval = TimeSpan.FromMilliseconds(200),
+            };
             dt.Tick += UpdateTick;
             dt.Start();
 
@@ -86,23 +84,23 @@
                 }
             }
 
-            var preferences = ServiceLocator.Instance.Get<IUserPreferences>();
-            if (preferences != null)
+            Preferences = ServiceLocator.Instance.Get<IUserPreferences>();
+            if (Preferences != null)
             {
-                if (preferences is INotifyPropertyChanged notify)
+                if (Preferences is INotifyPropertyChanged notify)
                 {
                     notify.PropertyChanged += (sender, args) =>
+                    {
+                        var prop = args.PropertyName;
+                        switch (prop)
                         {
-                            var prop = args.PropertyName;
-                            switch (prop)
-                            {
-                                case "SelectedTimeFormatOption":
-                                case "ConvertUtcTimesToLocalTimeZone":
-                                case "SelectedDateOption":
-                                    rebuildList = true;
-                                    break;
-                            }
-                        };
+                            case "SelectedTimeFormatOption":
+                            case "ConvertUtcTimesToLocalTimeZone":
+                            case "SelectedDateOption":
+                                rebuildList = true;
+                                break;
+                        }
+                    };
                 }
             }
 
@@ -110,6 +108,8 @@
         }
 
         public ObservableCollection<ILogEntry> Messages { get; private set; }
+
+        private IUserPreferences Preferences { get; }
 
         /// <summary>
         /// Gets or sets the count of filtered entries.
@@ -201,32 +201,34 @@
         private void InitialiseToolbar()
         {
             var autoScrollButton = new LogViewerToolbarButton(
-                                       "Auto-Scroll",
-                                       "Automatically scroll to show the newest entry",
-                                       true,
-                                       new DelegateCommand(e => autoScroll = !autoScroll))
-                                       {
-                                           IsChecked = autoScroll,
-                                           ImageIdentifier = "ScrollDown",
-                                       };
+                "Auto-Scroll",
+                "Automatically scroll to show the newest entry",
+                true,
+                new DelegateCommand(e => autoScroll = !autoScroll))
+            {
+                IsChecked = autoScroll,
+                ImageIdentifier = "ScrollDown",
+            };
 
-            var clearButton = new LogViewerToolbarButton("Clear", "Clear the log messages from the display", false, new DelegateCommand(e => clearPending = true))
-                                  {
-                                      ImageIdentifier = "Clear",
-                                  };
+            var clearButton = new LogViewerToolbarButton("Clear", "Clear the log messages from the display", false,
+                new DelegateCommand(e => clearPending = true))
+            {
+                ImageIdentifier = "Clear",
+            };
 
-            var pauseButton = new LogViewerToolbarButton("Pause", "Pause the addition of messages to the display", true, new DelegateCommand(PauseMessagesHandler))
-                                  {
-                                      IsChecked = false,
-                                      ImageIdentifier = "Pause",
-                                  };
+            var pauseButton = new LogViewerToolbarButton("Pause", "Pause the addition of messages to the display", true,
+                new DelegateCommand(PauseMessagesHandler))
+            {
+                IsChecked = false,
+                ImageIdentifier = "Pause",
+            };
 
             var toolbar = new ObservableCollection<ILogViewerToolbarButton>
-                              {
-                                  autoScrollButton,
-                                  clearButton,
-                                  pauseButton,
-                              };
+            {
+                autoScrollButton,
+                clearButton,
+                pauseButton,
+            };
 
             ToolbarItems = toolbar;
         }
@@ -355,6 +357,27 @@
                             var entry = pendingAdditions.Dequeue();
                             AddIfPassesFilters(entry);
                         }
+
+                        if (Preferences?.LimitMessages ?? false)
+                        {
+                            var limitAsString = Preferences?.MaximumMessageCount;
+                            if (int.TryParse(limitAsString, out var limit))
+                            {
+                                Logger.LimitMessageCount(limit);
+
+                                // Ensure filtered view is also limited.
+                                var messages = Messages.Count;
+                                var excessMessages = messages - limit;
+
+                                if (excessMessages > 0)
+                                {
+                                    for (; excessMessages > 0; excessMessages--)
+                                    {
+                                        Messages.RemoveAt(0);
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
 
@@ -428,7 +451,9 @@
                     }
 
                     var filtered = FilteredCount < UnfilteredCount;
-                    Status = filtered ? $"{FilteredCount} of {UnfilteredCount} Messages [Filters Applied]" : $"{UnfilteredCount} Messages";
+                    Status = filtered
+                        ? $"{FilteredCount} of {UnfilteredCount} Messages [Filters Applied]"
+                        : $"{UnfilteredCount} Messages";
                 }
             }
         }

--- a/Sentinel/Views/Gui/LogMessages.cs
+++ b/Sentinel/Views/Gui/LogMessages.cs
@@ -49,7 +49,7 @@
 
         public LogMessages()
         {
-            ((ViewInformation) Info).Description = DESCRIPTION;
+            ((ViewInformation)Info).Description = DESCRIPTION;
             presenter = new LogMessagesControl
             {
                 DataContext = this,
@@ -108,8 +108,6 @@
         }
 
         public ObservableCollection<ILogEntry> Messages { get; private set; }
-
-        private IUserPreferences Preferences { get; }
 
         /// <summary>
         /// Gets or sets the count of filtered entries.
@@ -187,6 +185,8 @@
         /// </summary>
         public Control Presenter => presenter;
 
+        private IUserPreferences Preferences { get; }
+
         public void SetLogger(ILogger newLogger)
         {
             Logger = newLogger;
@@ -210,13 +210,19 @@
                 ImageIdentifier = "ScrollDown",
             };
 
-            var clearButton = new LogViewerToolbarButton("Clear", "Clear the log messages from the display", false,
+            var clearButton = new LogViewerToolbarButton(
+                "Clear",
+                "Clear the log messages from the display",
+                false,
                 new DelegateCommand(e => clearPending = true))
             {
                 ImageIdentifier = "Clear",
             };
 
-            var pauseButton = new LogViewerToolbarButton("Pause", "Pause the addition of messages to the display", true,
+            var pauseButton = new LogViewerToolbarButton(
+                "Pause",
+                "Pause the addition of messages to the display",
+                true,
                 new DelegateCommand(PauseMessagesHandler))
             {
                 IsChecked = false,

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -2,8 +2,8 @@ using System;
 using System.Reflection;
 using System.Resources;
 
-[assembly: AssemblyVersion("0.13.5")]
-[assembly: AssemblyFileVersion("0.13.5")]
+[assembly: AssemblyVersion("0.14.0")]
+[assembly: AssemblyFileVersion("0.14.0")]
 
 // Ensure all assemblies have a neutral language defined.
 [assembly: NeutralResourcesLanguage("en")]


### PR DESCRIPTION
Implemented requested feature to limit number of log entries displayed by the logging window.
Limit may be enabled in Preferences and number of entries defined.

Addressed the lack of persistence of user preferences between sessions.  Settings made on the  General and Commands tab are saved on exit and reloaded.

Closes
#16 
#17 