### PR TITLE
Add basic serilog support

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,5 @@
+mode: Mainline
+branches: {}
+ignore:
+  sha: []
+merge-message-formats: {}

--- a/Sentinel.EventLogMonitor.Interfaces/Sentinel.EventLogMonitor.Interfaces.csproj
+++ b/Sentinel.EventLogMonitor.Interfaces/Sentinel.EventLogMonitor.Interfaces.csproj
@@ -53,6 +53,11 @@
     <PackageReference Include="Newtonsoft.Json">
       <Version>12.0.3</Version>
     </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers">
+      <Version>1.1.118</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/Sentinel.sln
+++ b/Sentinel.sln
@@ -39,6 +39,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Setup", "Setup", "{5D931689
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Testing Applications", "Testing Applications", "{D85E5F34-4DD4-467C-A69B-C3312FDB6FBF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SerilogTester", "SerilogTester\SerilogTester.csproj", "{A521BEE9-E9AA-49AA-9B9D-F98C4F95BD37}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -101,6 +103,10 @@ Global
 		{43D710A0-7805-4B0A-B38F-4A4D772800F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{43D710A0-7805-4B0A-B38F-4A4D772800F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{43D710A0-7805-4B0A-B38F-4A4D772800F6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A521BEE9-E9AA-49AA-9B9D-F98C4F95BD37}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A521BEE9-E9AA-49AA-9B9D-F98C4F95BD37}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A521BEE9-E9AA-49AA-9B9D-F98C4F95BD37}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A521BEE9-E9AA-49AA-9B9D-F98C4F95BD37}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -111,6 +117,7 @@ Global
 		{44D1E267-AE99-43BE-B824-980B4ABFF9CA} = {D85E5F34-4DD4-467C-A69B-C3312FDB6FBF}
 		{26533F90-3677-4565-84AE-928BCFDC7DFB} = {D85E5F34-4DD4-467C-A69B-C3312FDB6FBF}
 		{6E02A1CC-CFC2-48CD-95F5-3C0856AB9FF7} = {D85E5F34-4DD4-467C-A69B-C3312FDB6FBF}
+		{A521BEE9-E9AA-49AA-9B9D-F98C4F95BD37} = {D85E5F34-4DD4-467C-A69B-C3312FDB6FBF}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {28BEB7F3-F084-4255-BB5B-82292544AAA3}

--- a/Sentinel.sln.DotSettings
+++ b/Sentinel.sln.DotSettings
@@ -10,4 +10,6 @@
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=nlog/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Serilog/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Upgrader/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/SerilogTester/LogLevelGenerator.cs
+++ b/SerilogTester/LogLevelGenerator.cs
@@ -1,0 +1,16 @@
+﻿namespace SerilogTester
+{
+    using Bogus;
+
+    internal class LogLevelGenerator
+    {
+        private readonly Faker faker;
+
+        public LogLevelGenerator()
+        {
+            faker = new Faker();
+        }
+
+        public int Generate() => faker.Random.Int(0, 8);
+    }
+}

--- a/SerilogTester/Message.cs
+++ b/SerilogTester/Message.cs
@@ -1,0 +1,9 @@
+﻿namespace SerilogTester
+{
+    internal class Message
+    {
+        public string Value { get; set; }
+
+        public string Details { get; set; }
+    }
+}

--- a/SerilogTester/MessageGenerator.cs
+++ b/SerilogTester/MessageGenerator.cs
@@ -1,0 +1,18 @@
+﻿namespace SerilogTester
+{
+    using Bogus;
+
+    internal class MessageGenerator
+    {
+        private readonly Faker<Message> faker;
+
+        public MessageGenerator()
+        {
+            faker = new Faker<Message>()
+                .RuleFor(m => m.Details, faker => faker.Hacker.Phrase())
+                .RuleFor(m => m.Value, faker => faker.Hacker.Abbreviation());
+        }
+
+        public Message Generate() => faker.Generate();
+    }
+}

--- a/SerilogTester/Program.cs
+++ b/SerilogTester/Program.cs
@@ -1,0 +1,68 @@
+﻿namespace SerilogTester
+{
+    using System;
+    using System.Net.Sockets;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    using Bogus.Extensions;
+
+    using Serilog;
+    using Serilog.Sinks.Udp.TextFormatters;
+
+    public static class Program
+    {
+        private static Random random = new Random(1234);
+
+        private static void Main()
+        {
+            var logger = new LoggerConfiguration()
+                .WriteTo.Udp("localhost", 9999, AddressFamily.InterNetwork, new Log4jTextFormatter())
+                .WriteTo.Console()
+                .MinimumLevel.Verbose()
+                .CreateLogger();
+
+            ////var logger = new LoggerConfiguration()
+            ////    .WriteTo.Udp("localhost", 9998, AddressFamily.InterNetwork, new Log4netTextFormatter())
+            ////    .WriteTo.Console()
+            ////    .MinimumLevel.Verbose()
+            ////    .CreateLogger();
+
+            var sourceGenerator = new SourceGenerator();
+            var messageGenerator = new MessageGenerator();
+            var logLevelGenerator = new LogLevelGenerator();
+
+            while (true)
+            {
+                var source = sourceGenerator.Generate();
+                var message = messageGenerator.Generate();
+
+                switch (logLevelGenerator.Generate())
+                {
+                    case 1:
+                        logger.Information("Source: {@source}, Message: {@message}", source, message);
+                        break;
+                    case 2:
+                        logger.Warning("{@source}, {@message}", source, message);
+                        break;
+                    case 3:
+                        logger.Error("Something went wrong: {@source}, {@message}", source, message);
+                        break;
+                    case 4:
+                        var exception = new MissingFieldException(message.Value);
+                        logger.Fatal(exception, "Fatal Error!!! {@message}", message);
+                        break;
+                    case 5:
+                    case 6:
+                        logger.Debug("Simple debugging output {@source}, {@message}", source, message);
+                        break;
+                    default:
+                        logger.Verbose("{@source} = {@message}", source.Name, message.Value);
+                        break;
+                }
+
+                Thread.Sleep(1000);
+            }
+        }
+    }
+}

--- a/SerilogTester/SerilogTester.csproj
+++ b/SerilogTester/SerilogTester.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <CodeAnalysisRuleSet>..\StyleCop\StyleCopRules.ruleset</CodeAnalysisRuleSet>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <WarningsAsErrors />
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="..\StyleCop\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Bogus" Version="31.0.2" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
+    <PackageReference Include="Serilog.Sinks.Udp" Version="7.0.1" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/SerilogTester/Source.cs
+++ b/SerilogTester/Source.cs
@@ -1,0 +1,9 @@
+﻿namespace SerilogTester
+{
+    internal class Source
+    {
+        public string Name { get; set; }
+
+        public string Status { get; set; }
+    }
+}

--- a/SerilogTester/SourceGenerator.cs
+++ b/SerilogTester/SourceGenerator.cs
@@ -1,0 +1,18 @@
+﻿namespace SerilogTester
+{
+    using Bogus;
+
+    internal class SourceGenerator
+    {
+        private readonly Faker<Source> faker;
+
+        public SourceGenerator()
+        {
+            faker = new Faker<Source>().RuleFor(s => s.Name, faker => faker.Hacker.Phrase()).RuleFor(
+                s => s.Status,
+                faker => faker.Commerce.ProductAdjective());
+        }
+
+        public Source Generate() => faker.Generate();
+    }
+}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,13 +18,20 @@ steps:
   inputs:
     restoreSolution: '$(solution)'
 
+- task: GitVersion@5
+  inputs:
+    runtime: 'core'
+    configFilePath: 'GitVersion.yml'
+    updateAssemblyInfo: true
+    updateAssemblyInfoFilename: 'SharedAssemblyInfo.cs'
+
 - task: VSBuild@1
   inputs:
     solution: '$(solution)'
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
 
-- task: VSTest@2
-  inputs:
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
+#- task: VSTest@2
+#  inputs:
+#    platform: '$(buildPlatform)'
+#    configuration: '$(buildConfiguration)'


### PR DESCRIPTION
# Simple support for [serilog](https://serilog.net/), specifically for the [UDP sink](https://github.com/FantasticFiasco/serilog-sinks-udp).

Serilog has sinks for Udp that generate either log4net or log4j (used by nLog) formatted messages - but with some minor differences in the XML namespaces of the messages.  This pull request address both implementations to parse the message correctly.

Handling of the serilog generated messages mean that, depending upon which serilog format used the existing nLog and log4net implementations may be selected

## Using Sentinel's nLog provider
When using the `Log4jTextFormatter` formatter within the Serilog UDP sink, it would require selecting **NLOG** in Sentinel, this is the same message format NLOG uses.  

```csharp
var logger = new LoggerConfiguration()
    .WriteTo.Udp("localhost", 9999, AddressFamily.InterNetwork, new Log4jTextFormatter())
    .WriteTo.Console()
    .MinimumLevel.Verbose()
    .CreateLogger();
```

## Using sentinel's Log4net provider
When using the `Log4netTextFormatter` within Serilog UDP sink it would require you to select **LOG4NET** in Sentinel:

```csharp
var logger = new LoggerConfiguration()
   .WriteTo.Udp("localhost", 9998, AddressFamily.InterNetwork, new Log4netTextFormatter())
   .WriteTo.Console()
   .MinimumLevel.Verbose()
   .CreateLogger();
```

It should pick up properties and exceptions, the message displayed in description field of Sentinel is as passed from serilog, no specific processing is performed - I'm not sure what serilog can actually do, so suggestions for enhancements welcome.

PS. If you build from sources, specify `STANDALONE_BUILD` as a compilation directive to avoid worrying about the installers.

Closes #25