### PR TITLE
Reduce memory allocation for message pump for Log4Net + MsBuild + NLog

### DIFF
--- a/Sentinel/NLog/NLogViewerProvider.cs
+++ b/Sentinel/NLog/NLogViewerProvider.cs
@@ -118,23 +118,26 @@
             {
                 var endPoint = new IPEndPoint(IPAddress.Any, networkSettings.Port);
 
+                var networkProtocolDescription = networkSettings.Protocol.ToString();
+
                 using (var listener = new NetworkClientWrapper(networkSettings.Protocol, endPoint))
                 {
+                    listener.SetReceiveTimeout(1000);
+
+                    var remoteEndPoint = new IPEndPoint(IPAddress.Any, 0);
+
                     while (!cancellationTokenSource.IsCancellationRequested)
                     {
-                        var remoteEndPoint = new IPEndPoint(IPAddress.Any, 0);
-
-                        listener.SetReceiveTimeout(1000);
-
                         try
                         {
                             var bytes = listener.Receive(ref remoteEndPoint);
 
-                            Log.DebugFormat(
-                                "Received {0} bytes from {1} ({2})",
-                                bytes.Length,
-                                remoteEndPoint.Address,
-                                networkSettings.Protocol);
+                            if (Log.IsDebugEnabled)
+                                Log.DebugFormat(
+                                    "Received {0} bytes from {1} ({2})",
+                                    bytes.Length,
+                                    remoteEndPoint.Address,
+                                    networkProtocolDescription);
 
                             var message = Encoding.UTF8.GetString(bytes, 0, bytes.Length);
                             lock (pendingQueue)
@@ -146,7 +149,7 @@
                         {
                             if (socketException.SocketErrorCode != SocketError.TimedOut)
                             {
-                                Log.Debug("SocketException", socketException);
+                                Log.Error("SocketException", socketException);
                                 Log.DebugFormat(
                                     "SocketException.SocketErrorCode = {0}",
                                     socketException.SocketErrorCode);
@@ -157,7 +160,7 @@
                         }
                         catch (Exception e)
                         {
-                            Log.DebugFormat("Exception: {0}", e.Message);
+                            Log.Error("Network Exception", e);
                         }
                     }
                 }
@@ -170,6 +173,8 @@
         {
             Log.Debug("MessagePump started");
 
+            var processedQueue = new Queue<ILogEntry>();
+
             while (!cancellationTokenSource.IsCancellationRequested)
             {
                 Thread.Sleep(PumpFrequency);
@@ -180,8 +185,6 @@
                     {
                         lock (pendingQueue)
                         {
-                            var processedQueue = new Queue<ILogEntry>();
-
                             while (pendingQueue.Count > 0)
                             {
                                 var message = pendingQueue.Dequeue();
@@ -196,17 +199,21 @@
                                     }
                                 }
                             }
+                        }
 
-                            if (processedQueue.Any())
-                            {
-                                Logger.AddBatch(processedQueue);
-                            }
+                        if (processedQueue.Any())
+                        {
+                            Logger.AddBatch(processedQueue);
                         }
                     }
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine(e);
+                    Log.Error("MessagePump Exception", e);
+                }
+                finally
+                {
+                    processedQueue.Clear();
                 }
             }
 


### PR DESCRIPTION
Moved reusable objects outside the loops.