### PR TITLE
NLogViewerProvider - Fixed handling of TCP-stream

### DIFF
--- a/Sentinel/NLog/NLogViewerProvider.cs
+++ b/Sentinel/NLog/NLogViewerProvider.cs
@@ -120,17 +120,15 @@
 
                 var networkProtocolDescription = networkSettings.Protocol.ToString();
 
-                using (var listener = new NetworkClientWrapper(networkSettings.Protocol, endPoint))
+                using (var listener = new NetworkClientWrapper(networkSettings.Protocol, endPoint, cancellationTokenSource.Token))
                 {
-                    listener.SetReceiveTimeout(1000);
-
                     var remoteEndPoint = new IPEndPoint(IPAddress.Any, 0);
 
                     while (!cancellationTokenSource.IsCancellationRequested)
                     {
                         try
                         {
-                            var bytes = listener.Receive(ref remoteEndPoint);
+                            var bytes = listener.Receive(ref remoteEndPoint, 1000);
 
                             if (Log.IsDebugEnabled)
                                 Log.DebugFormat(


### PR DESCRIPTION
And chunk datagrams using newline.

Could not make the existing code work using TcpClient alone. TCP requires that the server-side accepts a TCP-socket, before it can receive data. TCP also doesn't have datagrams, but uses streaming, so used newline as datagram-separator in the stream.